### PR TITLE
Correct path for linking template files

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -23,7 +23,7 @@ vim Preferences/fileTemplates/includes/stmpfl_variables.txt
 **OS X**
 
 ```
-ln -s $(PWD)/magento2-phpstorm-templates/Preferences/templates/* ~/Library/Preferences/<product name><version number>/templates/
+ln -s $(PWD)/magento2-phpstorm-templates/Preferences/templates/* ~/Library/Preferences/<product name><version number>/settingsRepository/repository/templates/
 ln -s $(PWD)/magento2-phpstorm-templates/Preferences/fileTemplates/2M* ~/Library/Preferences/<product name><version number>/fileTemplates/
 ln -s $(PWD)/magento2-phpstorm-templates/Preferences/fileTemplates/includes/* ~/Library/Preferences/<product name><version number>/fileTemplates/includes/
 ln -s $(PWD)/magento2-phpstorm-templates/Preferences/fileTemplates/internal/* ~/Library/Preferences/<product name><version number>/fileTemplates/internal/


### PR DESCRIPTION
Copying file to ~/Library/Preferences/<product name><version number>/templates/ did not work.
PHPStorm only recognized the new templateSet after directly copying it to the settingsRepository.